### PR TITLE
Add JSON org dashboard endpoint and fix Testcontainers compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Reportcard is a test result metrics API and dashboard application. It stores, an
 ./gradlew test                       # Run unit tests
 ./gradlew integrationTest            # Run integration tests
 ./gradlew generateJooqSchemaSource   # Regenerate JOOQ code (requires local MySQL with schema)
-./gradlew bootRun                    # Run server locally
+./gradlew :reportcard-server:bootRun  # Run server locally
 ```
 
 To run a single test class:

--- a/reportcard-server/build.gradle
+++ b/reportcard-server/build.gradle
@@ -96,10 +96,10 @@ dependencies {
     implementation("software.amazon.awssdk.crt:aws-crt:${awsCrtVersion}")
 
     //AWS Test
-    testImplementation('org.testcontainers:localstack:1.20.0')
+    testImplementation('org.testcontainers:localstack:1.21.4')
 
     //DB Test
-    implementation platform('org.testcontainers:testcontainers-bom:1.20.0')
+    implementation platform('org.testcontainers:testcontainers-bom:1.21.4')
     testImplementation ("org.testcontainers:junit-jupiter")
     testImplementation('org.testcontainers:mysql')
 

--- a/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/controller/browse/BrowseJsonController.java
+++ b/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/controller/browse/BrowseJsonController.java
@@ -4,6 +4,7 @@ import io.github.ericdriggs.reportcard.cache.model.BranchStageViewResponse;
 import io.github.ericdriggs.reportcard.controller.browse.response.*;
 import io.github.ericdriggs.reportcard.gen.db.tables.pojos.*;
 import io.github.ericdriggs.reportcard.model.StageTestResultModel;
+import io.github.ericdriggs.reportcard.model.orgdashboard.OrgDashboard;
 import io.github.ericdriggs.reportcard.persist.BrowseService;
 import io.github.ericdriggs.reportcard.persist.GraphService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -49,6 +51,19 @@ public class BrowseJsonController {
             @PathVariable String company,
             @PathVariable String org) {
         return new ResponseEntity<>(OrgReposBranchesResponse.fromMap(browseService.getOrgReposBranches(company, org)), HttpStatus.OK);
+    }
+
+    @GetMapping(path = "company/{company}/org/{org}/dashboard", produces = "application/json")
+    public ResponseEntity<OrgDashboard> getOrgDashboardJson(
+            @PathVariable String company,
+            @PathVariable String org,
+            @RequestParam(required = false) List<String> repos,
+            @RequestParam(required = false, defaultValue = "") List<String> branches,
+            @RequestParam(required = false, defaultValue = "true") boolean shouldIncludeDefaultBranches,
+            @RequestParam(required = false) Integer days
+    ) {
+        OrgDashboard orgDashboard = graphService.getOrgDashboard(company, org, repos, branches, shouldIncludeDefaultBranches, days);
+        return new ResponseEntity<>(orgDashboard, HttpStatus.OK);
     }
 
     @GetMapping(path = {"company/{company}/org/{org}/repo/{repo}", "org/{org}/repo/{repo}/branch"}, produces = "application/json")

--- a/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/persist/GraphService.java
+++ b/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/persist/GraphService.java
@@ -287,7 +287,7 @@ public class GraphService extends AbstractPersistService {
                 ).fetchArray("MAX_RUN_ID", Long.class);
 
         tableConditionMap.put(RUN, RUN.RUN_ID.in(runIds));
-        return getCompanyGraphs(tableConditionMap);
+        return getCompanyGraphs(tableConditionMap, false);
 
     }
 


### PR DESCRIPTION
---
  Summary

  - Add JSON org dashboard endpoint at /json/company/{company}/org/{org}/dashboard for programmatic/agent access to the same data rendered by the
  HTML dashboard
  - Exclude testSuitesJson from the dashboard query to reduce response payload (~32KB JSON vs ~113KB with test suite details)
  - Upgrade Testcontainers from 1.20.0 to 1.21.4 to fix Docker Desktop 4.67+ API version negotiation (TC 1.20.0 sends API v1.32, rejected by Docker's
   minimum v1.40)
  - Fix bootRun command in CLAUDE.md for multi-module project

  Details

  The new endpoint mirrors the HTML dashboard's parameters exactly:
  - repos — filter to specific repos (regex match)
  - branches — filter to specific branches
  - shouldIncludeDefaultBranches — include dev/qa/staging/main/master (default: true)
  - days — limit to jobs with activity within N days

  Response is the OrgDashboard model serialized directly via Jackson (@Jacksonized), containing the full graph hierarchy: company → org → repos →
  branches → jobs → runs → stages → test results (aggregate counts, no individual test case data).

  Test plan

  - mise exec -- ./gradlew test -Si — all 346 tests pass
  - Local server verified: curl http://localhost:8080/json/company/hulu/org/SubLife/dashboard?days=30 returns valid JSON
  - Confirmed testSuitesJson excluded from response (null in test results)
  - HTML dashboard still works at same path without /json prefix