### PR TITLE
Add repo dashboard endpoint to query by repo name

### DIFF
--- a/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/controller/browse/BrowseJsonController.java
+++ b/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/controller/browse/BrowseJsonController.java
@@ -53,6 +53,17 @@ public class BrowseJsonController {
         return new ResponseEntity<>(OrgReposBranchesResponse.fromMap(browseService.getOrgReposBranches(company, org)), HttpStatus.OK);
     }
 
+    @GetMapping(path = "repo/{repoName}/dashboard", produces = "application/json")
+    public ResponseEntity<List<OrgDashboard>> getRepoDashboardJson(
+            @PathVariable String repoName,
+            @RequestParam(required = false, defaultValue = "") List<String> branches,
+            @RequestParam(required = false, defaultValue = "true") boolean shouldIncludeDefaultBranches,
+            @RequestParam(required = false) Integer days
+    ) {
+        List<OrgDashboard> repoDashboards = graphService.getRepoDashboard(repoName, branches, shouldIncludeDefaultBranches, days);
+        return new ResponseEntity<>(repoDashboards, HttpStatus.OK);
+    }
+
     @GetMapping(path = "company/{company}/org/{org}/dashboard", produces = "application/json")
     public ResponseEntity<OrgDashboard> getOrgDashboardJson(
             @PathVariable String company,

--- a/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/controller/graph/GraphUIController.java
+++ b/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/controller/graph/GraphUIController.java
@@ -75,6 +75,18 @@ public class GraphUIController {
         return new ResponseEntity<>(trendHtml, HttpStatus.OK);
     }
 
+    @GetMapping(path = "repo/{repoName}/dashboard", produces = "text/html;charset=UTF-8")
+    public ResponseEntity<String> getRepoDashboard(
+            @PathVariable String repoName,
+            @RequestParam(required = false, defaultValue = "") List<String> branches,
+            @RequestParam(required = false, defaultValue = "true") boolean shouldIncludeDefaultBranches,
+            @RequestParam(required = false) Integer days
+    ) {
+        final List<OrgDashboard> repoDashboards = graphService.getRepoDashboard(repoName, branches, shouldIncludeDefaultBranches, days);
+        final String dashboardHtml = OrgDashboardHtmlHelper.renderRepoDashboardHtml(repoName, repoDashboards);
+        return new ResponseEntity<>(dashboardHtml, HttpStatus.OK);
+    }
+
     @GetMapping(path = "company/{company}/org/{org}/dashboard", produces = "text/html;charset=UTF-8")
     public ResponseEntity<String> getOrgDashbarod(
             @PathVariable String company,

--- a/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/controller/graph/OrgDashboardHtmlHelper.java
+++ b/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/controller/graph/OrgDashboardHtmlHelper.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.CollectionUtils;
+import org.springframework.web.util.HtmlUtils;
 
 import java.net.URI;
 import java.util.*;
@@ -208,6 +209,51 @@ public class OrgDashboardHtmlHelper extends BrowseHtmlHelper {
 
         CompanyOrgRepoBranchJobRunStageDTO path = CompanyOrgRepoBranchJobRunStageDTO.builder().company(companyPojo.getCompanyName()).org(orgPojo.getOrgName()).build();
         return getBreadCrumb(path, "dashboard");
+    }
+
+    public static String renderRepoDashboardHtml(String repoName, List<OrgDashboard> orgDashboards) {
+        final String main = getRepoDashboardMainDiv(orgDashboards);
+        final List<Pair<String, String>> breadCrumbs = getRepoDashboardBreadCrumb(repoName);
+        return getPage(main, breadCrumbs, "dashboard-columns")
+                .replace("<!--additionalLinks-->", "<link rel=\"stylesheet\" href=\"/css/dashboard.css\">" + ls);
+    }
+
+    private static String getRepoDashboardMainDiv(List<OrgDashboard> orgDashboards) {
+        StringBuilder str = new StringBuilder();
+        for (OrgDashboard orgDashboard : orgDashboards) {
+            final String companyName = orgDashboard.getCompanyPojo().getCompanyName();
+            final String orgName = orgDashboard.getOrgPojo().getOrgName();
+
+            final CompanyOrgRepoBranchJobRunStageDTO companyPath = CompanyOrgRepoBranchJobRunStageDTO.builder()
+                    .company(companyName).build();
+            final CompanyOrgRepoBranchJobRunStageDTO orgPath = CompanyOrgRepoBranchJobRunStageDTO.builder()
+                    .company(companyName).org(orgName).build();
+
+            str.append("<fieldset class=\"company-fieldset fieldset-group\">").append(ls);
+            str.append("  <legend class='company-legend'>company: <a target=\"_blank\" href=\"{companyUrl}\">{companyName}</a></legend>"
+                    .replace("{companyUrl}", getUrl(companyPath))
+                    .replace("{companyName}", HtmlUtils.htmlEscape(companyName))
+            ).append(ls);
+
+            str.append("<fieldset class=\"org-fieldset fieldset-group\">").append(ls);
+            str.append("  <legend class='org-legend'>org: <a target=\"_blank\" href=\"{orgUrl}\">{orgName}</a></legend>"
+                    .replace("{orgUrl}", getUrl(orgPath))
+                    .replace("{orgName}", HtmlUtils.htmlEscape(orgName))
+            ).append(ls);
+
+            str.append(getOrgDashboardMainDiv(orgDashboard));
+
+            str.append("</fieldset><!--end-org-fieldset-->").append(ls);
+            str.append("</fieldset><!--end-company-fieldset-->").append(ls);
+        }
+        return str.toString();
+    }
+
+    protected static List<Pair<String, String>> getRepoDashboardBreadCrumb(String repoName) {
+        List<Pair<String, String>> breadCrumbs = new ArrayList<>();
+        breadCrumbs.add(Pair.of("home", getUrl(null)));
+        breadCrumbs.add(Pair.of("repo: " + HtmlUtils.htmlEscape(repoName), "/repo/" + repoName + "/dashboard"));
+        return breadCrumbs;
     }
 
 }

--- a/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/model/orgdashboard/OrgDashboard.java
+++ b/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/model/orgdashboard/OrgDashboard.java
@@ -10,6 +10,7 @@ import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 import org.springframework.util.CollectionUtils;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -20,6 +21,28 @@ public class OrgDashboard {
     CompanyPojo companyPojo;
     OrgPojo orgPojo;
     List<RepoGraph> repoGraphs;
+
+    public static List<OrgDashboard> listFromCompanyGraphs(List<CompanyGraph> companyGraphs) {
+        if (CollectionUtils.isEmpty(companyGraphs)) {
+            return Collections.emptyList();
+        }
+        List<OrgDashboard> results = new ArrayList<>();
+        for (CompanyGraph companyGraph : companyGraphs) {
+            List<OrgGraph> orgs = companyGraph.orgs() == null ? Collections.emptyList() : companyGraph.orgs();
+            for (OrgGraph orgGraph : orgs) {
+                List<RepoGraph> repos = orgGraph.repos() == null ? Collections.emptyList() : orgGraph.repos();
+                if (repos.isEmpty()) {
+                    continue;
+                }
+                results.add(OrgDashboard.builder()
+                        .companyPojo(companyGraph.asCompanyPojo())
+                        .orgPojo(orgGraph.asOrgPojo())
+                        .repoGraphs(repos)
+                        .build());
+            }
+        }
+        return results;
+    }
 
     public static OrgDashboard fromCompanyGraphs(List<CompanyGraph> companyGraphs) {
 

--- a/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/persist/GraphService.java
+++ b/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/persist/GraphService.java
@@ -291,6 +291,58 @@ public class GraphService extends AbstractPersistService {
 
     }
 
+    public List<OrgDashboard> getRepoDashboard(String repoName, List<String> branchNames, boolean shouldIncludeDefaultBranches, Integer days) {
+        List<CompanyGraph> companyGraphs = getRepoDashboardCompanyGraphs(repoName, branchNames, shouldIncludeDefaultBranches, days);
+        return OrgDashboard.listFromCompanyGraphs(companyGraphs);
+    }
+
+    List<CompanyGraph> getRepoDashboardCompanyGraphs(String repoName,
+                                                     List<String> branchNames,
+                                                     boolean shouldIncludeDefaultBranches,
+                                                     Integer days) {
+
+        TableConditionMap tableConditionMap = new TableConditionMap();
+        tableConditionMap.put(TEST_RESULT, TEST_RESULT.TEST_RESULT_ID.isNotNull());
+
+        Condition repoCondition = REPO.REPO_NAME.eq(repoName);
+        tableConditionMap.put(REPO, repoCondition);
+
+        branchNames = new ArrayList<>(branchNames);
+        if (shouldIncludeDefaultBranches) {
+            branchNames.addAll(defaultBranchNames);
+        }
+        tableConditionMap.put(BRANCH, BRANCH.BRANCH_NAME.in(branchNames));
+
+        if (days != null) {
+            Instant cutoff = Instant.now().minus(days, ChronoUnit.DAYS);
+            tableConditionMap.put(JOB, JOB.LAST_RUN.ge(cutoff));
+        }
+
+        Long[] runIds = dsl.select(max(RUN.RUN_ID).as("MAX_RUN_ID"))
+                .from(COMPANY)
+                .leftJoin(ORG).on(ORG.COMPANY_FK.eq(COMPANY.COMPANY_ID))
+                .leftJoin(REPO).on(REPO.ORG_FK.eq(ORG.ORG_ID)).and(repoCondition)
+                .leftJoin(BRANCH).on(BRANCH.REPO_FK.eq(REPO.REPO_ID).and(BRANCH.BRANCH_NAME.in(branchNames)))
+                .leftJoin(JOB).on(JOB.BRANCH_FK.eq(BRANCH.BRANCH_ID))
+                .leftJoin(RUN).on(RUN.JOB_FK.eq(JOB.JOB_ID))
+                .leftJoin(STAGE).on(STAGE.RUN_FK.eq(RUN.RUN_ID))
+                .groupBy(JOB.JOB_ID, STAGE.STAGE_NAME)
+                .union(
+                        select(max(RUN.RUN_ID))
+                                .from(COMPANY)
+                                .leftJoin(ORG).on(ORG.COMPANY_FK.eq(COMPANY.COMPANY_ID))
+                                .leftJoin(REPO).on(REPO.ORG_FK.eq(ORG.ORG_ID)).and(repoCondition)
+                                .leftJoin(BRANCH).on(BRANCH.REPO_FK.eq(REPO.REPO_ID).and(BRANCH.BRANCH_NAME.in(branchNames)))
+                                .leftJoin(JOB).on(JOB.BRANCH_FK.eq(BRANCH.BRANCH_ID))
+                                .leftJoin(RUN).on(RUN.JOB_FK.eq(JOB.JOB_ID).and(RUN.IS_SUCCESS))
+                                .leftJoin(STAGE).on(STAGE.RUN_FK.eq(RUN.RUN_ID))
+                                .groupBy(JOB.JOB_ID, STAGE.STAGE_NAME)
+                ).fetchArray("MAX_RUN_ID", Long.class);
+
+        tableConditionMap.put(RUN, RUN.RUN_ID.in(runIds));
+        return getCompanyGraphs(tableConditionMap, false);
+    }
+
     public TreeSet<MetricsIntervalResultCount> getCompanyDashboardIntervalResultCount(MetricsIntervalRequest metricsIntervalRequest) {
         TreeSet<MetricsRequest> metricsRequests = metricsIntervalRequest.toCompanyDashboardRequests();
         Set<MetricsIntervalResultCount> results = new ConcurrentSkipListSet<>();


### PR DESCRIPTION
## Summary
- Adds `GET /repo/{repoName}/dashboard` (UI) and `GET /json/repo/{repoName}/dashboard` (JSON) endpoints that return dashboard data for all company/org pairs containing the specified repo
- Supports `branches`, `shouldIncludeDefaultBranches`, and `days` query parameters (same as existing org dashboard)
- Filters out orgs with no matching repos from the response
- HTML-escapes user-provided values (repoName, companyName, orgName) in rendered output

## Test plan
- [x] `./gradlew build` compiles successfully
- [x] `GET /json/repo/{repoName}/dashboard?days=30` returns JSON with companyPojo, orgPojo, repoGraphs
- [x] `GET /repo/{repoName}/dashboard?days=30` returns HTML with company/org fieldsets wrapping repo content
- [x] `GET /json/repo/{repoName}/dashboard?branches=main,master&days=30` verifies branch filtering
- [x] Entries with empty `repoGraphs` are excluded from response
- [x] XSS attempt in repoName path variable is escaped in HTML output (`"` → `&quot;`)
- [x] Non-existent repo returns empty `[]` with HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)