### PR TITLE
Job info endpoints

### DIFF
--- a/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/controller/browse/BrowseJsonController.java
+++ b/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/controller/browse/BrowseJsonController.java
@@ -12,6 +12,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import io.github.ericdriggs.reportcard.util.StringMapUtil;
+
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -115,6 +117,20 @@ public class BrowseJsonController {
         return new ResponseEntity<>(JobRunsStagesResponse.fromMap(limitRunsInJob(fullResult, runs)), HttpStatus.OK);
     }
 
+    @GetMapping(path = {"company/{company}/org/{org}/repo/{repo}/branch/{branch}/jobinfo/{jobInfo}",
+            "company/{company}/org/{org}/repo/{repo}/branch/{branch}/jobinfo/{jobInfo}/run"}, produces = "application/json")
+    public ResponseEntity<JobRunsStagesResponse> getJobRunsStagesFromJobInfo(
+            @PathVariable String company,
+            @PathVariable String org,
+            @PathVariable String repo,
+            @PathVariable String branch,
+            @PathVariable String jobInfo,
+            @RequestParam(required = false, defaultValue = "60") Integer runs) {
+        Map<String, String> jobInfoMap = StringMapUtil.stringToMap(jobInfo);
+        JobPojo job = browseService.getJob(company, org, repo, branch, jobInfoMap);
+        return getJobRunsStages(company, org, repo, branch, job.getJobId(), runs);
+    }
+
     @GetMapping(path = {"company/{company}/org/{org}/repo/{repo}/branch/{branch}/job/{jobId}/run/{runId}",
             "company/{company}/org/{org}/repo/{repo}/branch/{branch}/job/{jobId}/run/{runId}/stage"}, produces = "application/json")
     public ResponseEntity<RunStagesTestResultsResponse> getStagesByIds(
@@ -128,6 +144,20 @@ public class BrowseJsonController {
         return new ResponseEntity<>(RunStagesTestResultsResponse.fromBranchStageViewResponse(result), HttpStatus.OK);
     }
 
+    @GetMapping(path = {"company/{company}/org/{org}/repo/{repo}/branch/{branch}/jobinfo/{jobInfo}/runcount/{runCount}",
+            "company/{company}/org/{org}/repo/{repo}/branch/{branch}/jobinfo/{jobInfo}/runcount/{runCount}/stage"}, produces = "application/json")
+    public ResponseEntity<RunStagesTestResultsResponse> getStagesByJobInfoAndRunCount(
+            @PathVariable String company,
+            @PathVariable String org,
+            @PathVariable String repo,
+            @PathVariable String branch,
+            @PathVariable String jobInfo,
+            @PathVariable Integer runCount) {
+        Map<String, String> jobInfoMap = StringMapUtil.stringToMap(jobInfo);
+        BranchStageViewResponse result = graphService.getRunBranchStageViewResponse(company, org, repo, branch, jobInfoMap, runCount);
+        return new ResponseEntity<>(RunStagesTestResultsResponse.fromBranchStageViewResponse(result), HttpStatus.OK);
+    }
+
     @GetMapping(path = "company/{company}/org/{org}/repo/{repo}/branch/{branch}/job/{jobId}/run/latest",
                 produces = "application/json")
     public ResponseEntity<RunStagesTestResultsResponse> getLatestRunStages(
@@ -138,6 +168,20 @@ public class BrowseJsonController {
             @PathVariable Long jobId) {
         Long latestRunId = browseService.getLatestRunId(jobId);
         return getStagesByIds(company, org, repo, branch, jobId, latestRunId);
+    }
+
+    @GetMapping(path = "company/{company}/org/{org}/repo/{repo}/branch/{branch}/jobinfo/{jobInfo}/run/latest",
+                produces = "application/json")
+    public ResponseEntity<RunStagesTestResultsResponse> getLatestRunStagesFromJobInfo(
+            @PathVariable String company,
+            @PathVariable String org,
+            @PathVariable String repo,
+            @PathVariable String branch,
+            @PathVariable String jobInfo) {
+        Map<String, String> jobInfoMap = StringMapUtil.stringToMap(jobInfo);
+        JobPojo job = browseService.getJob(company, org, repo, branch, jobInfoMap);
+        Long latestRunId = browseService.getLatestRunId(job.getJobId());
+        return getStagesByIds(company, org, repo, branch, job.getJobId(), latestRunId);
     }
 
     @GetMapping(path = "company/{company}/org/{org}/repo/{repo}/branch/{branch}/sha/{sha}/run", produces = "application/json")
@@ -176,6 +220,20 @@ public class BrowseJsonController {
         return new ResponseEntity<>(browseService.getStageTestResultMap(company, org, repo, branch, jobId, runId, stage), HttpStatus.OK);
     }
 
+    @GetMapping(path = "company/{company}/org/{org}/repo/{repo}/branch/{branch}/jobinfo/{jobInfo}/runcount/{runCount}/stage/{stage}",
+                produces = "application/json")
+    public ResponseEntity<StageTestResultModel> getStageTestResultsByJobInfoAndRunCount(
+            @PathVariable String company,
+            @PathVariable String org,
+            @PathVariable String repo,
+            @PathVariable String branch,
+            @PathVariable String jobInfo,
+            @PathVariable Integer runCount,
+            @PathVariable String stage) {
+        Map<String, String> jobInfoMap = StringMapUtil.stringToMap(jobInfo);
+        return new ResponseEntity<>(browseService.getStageTestResultMap(company, org, repo, branch, jobInfoMap, runCount, stage), HttpStatus.OK);
+    }
+
     @GetMapping(path = "company/{company}/org/{org}/repo/{repo}/branch/{branch}/job/{jobId}/run/latest/stage/{stage}",
                 produces = "application/json")
     public ResponseEntity<StageTestResultModel> getLatestRunStageTestResults(
@@ -187,6 +245,21 @@ public class BrowseJsonController {
             @PathVariable String stage) {
         Long latestRunId = browseService.getLatestRunId(jobId);
         return getStageTestResultsTestSuites(company, org, repo, branch, jobId, latestRunId, stage);
+    }
+
+    @GetMapping(path = "company/{company}/org/{org}/repo/{repo}/branch/{branch}/jobinfo/{jobInfo}/run/latest/stage/{stage}",
+                produces = "application/json")
+    public ResponseEntity<StageTestResultModel> getLatestRunStageTestResultsFromJobInfo(
+            @PathVariable String company,
+            @PathVariable String org,
+            @PathVariable String repo,
+            @PathVariable String branch,
+            @PathVariable String jobInfo,
+            @PathVariable String stage) {
+        Map<String, String> jobInfoMap = StringMapUtil.stringToMap(jobInfo);
+        JobPojo job = browseService.getJob(company, org, repo, branch, jobInfoMap);
+        Long latestRunId = browseService.getLatestRunId(job.getJobId());
+        return getStageTestResultsTestSuites(company, org, repo, branch, job.getJobId(), latestRunId, stage);
     }
 
     // ==================== Helper Methods ====================

--- a/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/controller/browse/BrowseUIController.java
+++ b/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/controller/browse/BrowseUIController.java
@@ -1,6 +1,7 @@
 package io.github.ericdriggs.reportcard.controller.browse;
 
 import io.github.ericdriggs.reportcard.cache.model.*;
+import io.github.ericdriggs.reportcard.gen.db.tables.pojos.JobPojo;
 import io.github.ericdriggs.reportcard.controller.html.TestResultHtmlHelper;
 import io.github.ericdriggs.reportcard.model.StageTestResultModel;
 import io.github.ericdriggs.reportcard.model.branch.BranchJobLatestRunMap;
@@ -155,6 +156,19 @@ public class BrowseUIController {
         return getStageTestResults(company, org, repo, branch, jobId, latestRunId);
     }
 
+    @GetMapping(path = {"company/{company}/org/{org}/repo/{repo}/branch/{branch}/jobinfo/{jobInfo}/run/latest"}, produces = "text/html;charset=UTF-8")
+    public ResponseEntity<String> getLatestRunStagesFromJobInfo(
+            @PathVariable String company,
+            @PathVariable String org,
+            @PathVariable String repo,
+            @PathVariable String branch,
+            @PathVariable String jobInfo) {
+        Map<String, String> jobInfoMap = StringMapUtil.stringToMap(jobInfo);
+        JobPojo job = browseService.getJob(company, org, repo, branch, jobInfoMap);
+        Long latestRunId = browseService.getLatestRunId(job.getJobId());
+        return getStageTestResults(company, org, repo, branch, job.getJobId(), latestRunId);
+    }
+
     @GetMapping(path = {"company/{company}/org/{org}/repo/{repo}/branch/{branch}/job/{jobId}/run/{runId}/stage/{stage}"}, produces = "text/html;charset=UTF-8")
     public ResponseEntity<String> getTestResult(
             @PathVariable String company,
@@ -166,18 +180,6 @@ public class BrowseUIController {
             @PathVariable String stage) {
         StageTestResultModel stageTestResultModel = browseService.getStageTestResultMap(company, org, repo, branch , jobId, runId, stage);
         return new ResponseEntity<>(TestResultHtmlHelper.getTestResult(stageTestResultModel.getTestResult()), HttpStatus.OK);
-    }
-
-    @GetMapping(path = {"company/{company}/org/{org}/repo/{repo}/branch/{branch}/job/{jobId}/run/latest/stage/{stage}"}, produces = "text/html;charset=UTF-8")
-    public ResponseEntity<String> getLatestRunStageTestResult(
-            @PathVariable String company,
-            @PathVariable String org,
-            @PathVariable String repo,
-            @PathVariable String branch,
-            @PathVariable Long jobId,
-            @PathVariable String stage) {
-        Long latestRunId = browseService.getLatestRunId(jobId);
-        return getTestResult(company, org, repo, branch, jobId, latestRunId, stage);
     }
 
     @GetMapping(path = {"company/{company}/org/{org}/repo/{repo}/branch/{branch}/jobinfo/{jobInfo}/runcount/{runCount}/stage/{stage}"}, produces = "text/html;charset=UTF-8")
@@ -193,6 +195,32 @@ public class BrowseUIController {
         TreeMap<String,String> jobInfoMap = StringMapUtil.stringToMap(jobInfo);
         StageTestResultModel stageTestResultModel = browseService.getStageTestResultMap(company, org, repo, branch , jobInfoMap, runCount, stage);
         return new ResponseEntity<>(TestResultHtmlHelper.getTestResult(stageTestResultModel.getTestResult()), HttpStatus.OK);
+    }
+
+    @GetMapping(path = {"company/{company}/org/{org}/repo/{repo}/branch/{branch}/job/{jobId}/run/latest/stage/{stage}"}, produces = "text/html;charset=UTF-8")
+    public ResponseEntity<String> getLatestRunStageTestResult(
+            @PathVariable String company,
+            @PathVariable String org,
+            @PathVariable String repo,
+            @PathVariable String branch,
+            @PathVariable Long jobId,
+            @PathVariable String stage) {
+        Long latestRunId = browseService.getLatestRunId(jobId);
+        return getTestResult(company, org, repo, branch, jobId, latestRunId, stage);
+    }
+
+    @GetMapping(path = {"company/{company}/org/{org}/repo/{repo}/branch/{branch}/jobinfo/{jobInfo}/run/latest/stage/{stage}"}, produces = "text/html;charset=UTF-8")
+    public ResponseEntity<String> getLatestRunStageTestResultFromJobInfo(
+            @PathVariable String company,
+            @PathVariable String org,
+            @PathVariable String repo,
+            @PathVariable String branch,
+            @PathVariable String jobInfo,
+            @PathVariable String stage) {
+        Map<String, String> jobInfoMap = StringMapUtil.stringToMap(jobInfo);
+        JobPojo job = browseService.getJob(company, org, repo, branch, jobInfoMap);
+        Long latestRunId = browseService.getLatestRunId(job.getJobId());
+        return getTestResult(company, org, repo, branch, job.getJobId(), latestRunId, stage);
     }
 
     Integer validateRuns(int runs) {

--- a/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/controller/graph/GraphJsonController.java
+++ b/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/controller/graph/GraphJsonController.java
@@ -1,12 +1,14 @@
 package io.github.ericdriggs.reportcard.controller.graph;
 
+import io.github.ericdriggs.reportcard.gen.db.tables.pojos.JobPojo;
 import io.github.ericdriggs.reportcard.model.metrics.company.MetricsIntervalRequest;
 import io.github.ericdriggs.reportcard.model.metrics.company.MetricsIntervalResultCount;
 import io.github.ericdriggs.reportcard.model.pipeline.JobDashboardMetrics;
 import io.github.ericdriggs.reportcard.model.pipeline.JobDashboardRequest;
 import io.github.ericdriggs.reportcard.model.trend.JobStageTestTrend;
+import io.github.ericdriggs.reportcard.persist.BrowseService;
 import io.github.ericdriggs.reportcard.persist.GraphService;
-import io.github.ericdriggs.reportcard.controller.graph.JobInfoParser;
+import io.github.ericdriggs.reportcard.util.StringMapUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -14,7 +16,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
@@ -25,12 +26,12 @@ import java.util.TreeSet;
 public class GraphJsonController {
 
     private final GraphService graphService;
+    private final BrowseService browseService;
 
     @Autowired
-    public GraphJsonController(GraphService graphService) {
-
+    public GraphJsonController(GraphService graphService, BrowseService browseService) {
         this.graphService = graphService;
-
+        this.browseService = browseService;
     }
 
     @GetMapping(path = "company/{company}/org/{org}/repo/{repo}/branch/{branch}/job/{jobId}/stage/{stage}/trend", produces = "application/json")
@@ -47,6 +48,21 @@ public class GraphJsonController {
         return new ResponseEntity<>(graphService.getJobStageTestTrend(company, org, repo, branch, jobId, stage, start, end, 30), HttpStatus.OK);
     }
 
+    @GetMapping(path = "company/{company}/org/{org}/repo/{repo}/branch/{branch}/jobinfo/{jobInfo}/stage/{stage}/trend", produces = "application/json")
+    public ResponseEntity<JobStageTestTrend> getJobStageTestTrendFromJobInfo(
+            @PathVariable String company,
+            @PathVariable String org,
+            @PathVariable String repo,
+            @PathVariable String branch,
+            @PathVariable String jobInfo,
+            @PathVariable String stage,
+            @RequestParam(required = false) Instant start,
+            @RequestParam(required = false) Instant end
+    ) {
+        Map<String, String> jobInfoMap = StringMapUtil.stringToMap(jobInfo);
+        JobPojo job = browseService.getJob(company, org, repo, branch, jobInfoMap);
+        return getJobStageTestTrend(company, org, repo, branch, job.getJobId(), stage, start, end);
+    }
 
     @GetMapping(path = "metrics/all", produces = "application/json")
     @Operation(summary = "Get metrics using query parameters",

--- a/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/controller/graph/GraphUIController.java
+++ b/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/controller/graph/GraphUIController.java
@@ -1,15 +1,16 @@
 package io.github.ericdriggs.reportcard.controller.graph;
 
+import io.github.ericdriggs.reportcard.gen.db.tables.pojos.JobPojo;
 import io.github.ericdriggs.reportcard.model.metrics.company.MetricsIntervalRequest;
 import io.github.ericdriggs.reportcard.model.metrics.company.MetricsIntervalResultCount;
 import io.github.ericdriggs.reportcard.model.metrics.company.MetricsIntervalResultCountMaps;
 import io.github.ericdriggs.reportcard.model.orgdashboard.OrgDashboard;
-import io.github.ericdriggs.reportcard.model.pipeline.JobDashboardRequest;
 import io.github.ericdriggs.reportcard.model.pipeline.JobDashboardMetrics;
-
+import io.github.ericdriggs.reportcard.model.pipeline.JobDashboardRequest;
 import io.github.ericdriggs.reportcard.model.trend.JobStageTestTrend;
+import io.github.ericdriggs.reportcard.persist.BrowseService;
 import io.github.ericdriggs.reportcard.persist.GraphService;
-import io.github.ericdriggs.reportcard.controller.graph.JobInfoParser;
+import io.github.ericdriggs.reportcard.util.StringMapUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,9 +20,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.view.RedirectView;
 
 import javax.servlet.http.HttpServletRequest;
-
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
@@ -33,10 +32,12 @@ import java.util.TreeSet;
 public class GraphUIController {
 
     private final GraphService graphService;
+    private final BrowseService browseService;
 
     @Autowired
-    public GraphUIController(GraphService graphService) {
+    public GraphUIController(GraphService graphService, BrowseService browseService) {
         this.graphService = graphService;
+        this.browseService = browseService;
     }
 
     @GetMapping(path = "company/{company}/org/{org}/repo/{repo}/branch/{branch}/job/{jobId}/stage/{stage}/trend", produces = "text/html;charset=UTF-8")
@@ -73,6 +74,23 @@ public class GraphUIController {
         }
         //TODO: add cache headers * browser side cache using header, e.g. Cache-Control: max-age=600 //10 mins
         return new ResponseEntity<>(trendHtml, HttpStatus.OK);
+    }
+
+    @GetMapping(path = "company/{company}/org/{org}/repo/{repo}/branch/{branch}/jobinfo/{jobInfo}/stage/{stage}/trend", produces = "text/html;charset=UTF-8")
+    public ResponseEntity<String> getJobStageTestTrendFromJobInfo(
+            @PathVariable String company,
+            @PathVariable String org,
+            @PathVariable String repo,
+            @PathVariable String branch,
+            @PathVariable String jobInfo,
+            @PathVariable String stage,
+            @RequestParam(required = false) Instant start,
+            @RequestParam(required = false) Instant end,
+            @RequestParam(required = false, defaultValue = "30") Integer runs
+    ) {
+        Map<String, String> jobInfoMap = StringMapUtil.stringToMap(jobInfo);
+        JobPojo job = browseService.getJob(company, org, repo, branch, jobInfoMap);
+        return getJobStageTestTrend(company, org, repo, branch, job.getJobId(), stage, start, end, runs);
     }
 
     @GetMapping(path = "repo/{repoName}/dashboard", produces = "text/html;charset=UTF-8")

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/browse/BrowseJsonControllerJobInfoTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/browse/BrowseJsonControllerJobInfoTest.java
@@ -1,0 +1,159 @@
+package io.github.ericdriggs.reportcard.controller.browse;
+
+import io.github.ericdriggs.reportcard.controller.browse.response.*;
+import io.github.ericdriggs.reportcard.gen.db.TestData;
+import io.github.ericdriggs.reportcard.model.StageTestResultModel;
+import io.github.ericdriggs.reportcard.persist.BrowseService;
+import io.github.ericdriggs.reportcard.persist.browse.AbstractBrowseServiceTest;
+import io.github.ericdriggs.reportcard.util.StringMapUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BrowseJsonControllerJobInfoTest extends AbstractBrowseServiceTest {
+
+    private final BrowseJsonController controller;
+    private final BrowseService browseService;
+    private final String jobInfoString = StringMapUtil.toEqualsCsv(TestData.jobInfo);
+
+    @Autowired
+    public BrowseJsonControllerJobInfoTest(BrowseService browseService, BrowseJsonController controller) {
+        super(browseService);
+        this.browseService = browseService;
+        this.controller = controller;
+    }
+
+    @Test
+    void getJobRunsStagesFromJobInfoSuccessTest() {
+        ResponseEntity<JobRunsStagesResponse> response =
+            controller.getJobRunsStagesFromJobInfo(
+                TestData.company, TestData.org, TestData.repo, TestData.branch, jobInfoString, null);
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        JobRunsStagesResponse body = response.getBody();
+        assertNotNull(body);
+        assertEquals(TestData.jobId, body.getJobId());
+        assertNotNull(body.getRuns());
+        assertFalse(body.getRuns().isEmpty());
+    }
+
+    @Test
+    void getJobRunsStagesFromJobInfoMatchesJobIdTest() {
+        ResponseEntity<JobRunsStagesResponse> jobInfoResponse =
+            controller.getJobRunsStagesFromJobInfo(
+                TestData.company, TestData.org, TestData.repo, TestData.branch, jobInfoString, null);
+
+        ResponseEntity<JobRunsStagesResponse> jobIdResponse =
+            controller.getJobRunsStages(
+                TestData.company, TestData.org, TestData.repo, TestData.branch, TestData.jobId, null);
+
+        assertNotNull(jobInfoResponse.getBody());
+        assertNotNull(jobIdResponse.getBody());
+        assertEquals(jobIdResponse.getBody().getJobId(), jobInfoResponse.getBody().getJobId());
+        assertEquals(jobIdResponse.getBody().getRuns().size(), jobInfoResponse.getBody().getRuns().size());
+    }
+
+    @Test
+    void getStagesByJobInfoAndRunCountSuccessTest() {
+        ResponseEntity<RunStagesTestResultsResponse> response =
+            controller.getStagesByJobInfoAndRunCount(
+                TestData.company, TestData.org, TestData.repo, TestData.branch, jobInfoString, 1);
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        RunStagesTestResultsResponse body = response.getBody();
+        assertNotNull(body);
+        assertNotNull(body.getStages());
+        assertFalse(body.getStages().isEmpty());
+    }
+
+    @Test
+    void getLatestRunStagesFromJobInfoSuccessTest() {
+        ResponseEntity<RunStagesTestResultsResponse> response =
+            controller.getLatestRunStagesFromJobInfo(
+                TestData.company, TestData.org, TestData.repo, TestData.branch, jobInfoString);
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        RunStagesTestResultsResponse body = response.getBody();
+        assertNotNull(body);
+        assertNotNull(body.getRunId());
+        assertNotNull(body.getStages());
+        assertFalse(body.getStages().isEmpty());
+    }
+
+    @Test
+    void getLatestRunStagesFromJobInfoMatchesJobIdTest() {
+        ResponseEntity<RunStagesTestResultsResponse> jobInfoResponse =
+            controller.getLatestRunStagesFromJobInfo(
+                TestData.company, TestData.org, TestData.repo, TestData.branch, jobInfoString);
+
+        ResponseEntity<RunStagesTestResultsResponse> jobIdResponse =
+            controller.getLatestRunStages(
+                TestData.company, TestData.org, TestData.repo, TestData.branch, TestData.jobId);
+
+        assertNotNull(jobInfoResponse.getBody());
+        assertNotNull(jobIdResponse.getBody());
+        assertEquals(jobIdResponse.getBody().getRunId(), jobInfoResponse.getBody().getRunId());
+    }
+
+    @Test
+    void getStageTestResultsByJobInfoAndRunCountSuccessTest() {
+        ResponseEntity<StageTestResultModel> response =
+            controller.getStageTestResultsByJobInfoAndRunCount(
+                TestData.company, TestData.org, TestData.repo, TestData.branch,
+                jobInfoString, 1, TestData.stage);
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        StageTestResultModel body = response.getBody();
+        assertNotNull(body);
+        assertNotNull(body.getStage());
+        assertEquals(TestData.stage, body.getStage().getStageName());
+        assertNotNull(body.getTestResult());
+    }
+
+    @Test
+    void getLatestRunStageTestResultsFromJobInfoSuccessTest() {
+        ResponseEntity<StageTestResultModel> response =
+            controller.getLatestRunStageTestResultsFromJobInfo(
+                TestData.company, TestData.org, TestData.repo, TestData.branch,
+                jobInfoString, TestData.stage);
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        StageTestResultModel body = response.getBody();
+        assertNotNull(body);
+        assertNotNull(body.getStage());
+        assertEquals(TestData.stage, body.getStage().getStageName());
+    }
+
+    @Test
+    void getLatestRunStageTestResultsFromJobInfoMatchesJobIdTest() {
+        ResponseEntity<StageTestResultModel> jobInfoResponse =
+            controller.getLatestRunStageTestResultsFromJobInfo(
+                TestData.company, TestData.org, TestData.repo, TestData.branch,
+                jobInfoString, TestData.stage);
+
+        ResponseEntity<StageTestResultModel> jobIdResponse =
+            controller.getLatestRunStageTestResults(
+                TestData.company, TestData.org, TestData.repo, TestData.branch,
+                TestData.jobId, TestData.stage);
+
+        assertNotNull(jobInfoResponse.getBody());
+        assertNotNull(jobIdResponse.getBody());
+        assertEquals(jobIdResponse.getBody().getStage().getStageId(),
+            jobInfoResponse.getBody().getStage().getStageId());
+        assertEquals(jobIdResponse.getBody().getTestResult().getTestResultId(),
+            jobInfoResponse.getBody().getTestResult().getTestResultId());
+    }
+}

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/browse/BrowseJsonControllerJobInfoTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/browse/BrowseJsonControllerJobInfoTest.java
@@ -74,6 +74,25 @@ public class BrowseJsonControllerJobInfoTest extends AbstractBrowseServiceTest {
     }
 
     @Test
+    void getStagesByJobInfoAndRunCountMatchesLatestTest() {
+        ResponseEntity<RunStagesTestResultsResponse> runCountResponse =
+            controller.getStagesByJobInfoAndRunCount(
+                TestData.company, TestData.org, TestData.repo, TestData.branch, jobInfoString, 1);
+
+        ResponseEntity<RunStagesTestResultsResponse> latestResponse =
+            controller.getLatestRunStagesFromJobInfo(
+                TestData.company, TestData.org, TestData.repo, TestData.branch, jobInfoString);
+
+        assertNotNull(runCountResponse.getBody());
+        assertNotNull(latestResponse.getBody());
+        assertEquals(latestResponse.getBody().getRunId(), runCountResponse.getBody().getRunId());
+        assertEquals(latestResponse.getBody().getStages().size(), runCountResponse.getBody().getStages().size());
+        assertEquals(
+            latestResponse.getBody().getStages().get(0).getStageId(),
+            runCountResponse.getBody().getStages().get(0).getStageId());
+    }
+
+    @Test
     void getLatestRunStagesFromJobInfoSuccessTest() {
         ResponseEntity<RunStagesTestResultsResponse> response =
             controller.getLatestRunStagesFromJobInfo(
@@ -119,6 +138,26 @@ public class BrowseJsonControllerJobInfoTest extends AbstractBrowseServiceTest {
         assertNotNull(body.getStage());
         assertEquals(TestData.stage, body.getStage().getStageName());
         assertNotNull(body.getTestResult());
+    }
+
+    @Test
+    void getStageTestResultsByJobInfoAndRunCountMatchesLatestTest() {
+        ResponseEntity<StageTestResultModel> runCountResponse =
+            controller.getStageTestResultsByJobInfoAndRunCount(
+                TestData.company, TestData.org, TestData.repo, TestData.branch,
+                jobInfoString, 1, TestData.stage);
+
+        ResponseEntity<StageTestResultModel> latestResponse =
+            controller.getLatestRunStageTestResultsFromJobInfo(
+                TestData.company, TestData.org, TestData.repo, TestData.branch,
+                jobInfoString, TestData.stage);
+
+        assertNotNull(runCountResponse.getBody());
+        assertNotNull(latestResponse.getBody());
+        assertEquals(latestResponse.getBody().getStage().getStageId(),
+            runCountResponse.getBody().getStage().getStageId());
+        assertEquals(latestResponse.getBody().getTestResult().getTestResultId(),
+            runCountResponse.getBody().getTestResult().getTestResultId());
     }
 
     @Test

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/browse/BrowseUIControllerJobInfoTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/browse/BrowseUIControllerJobInfoTest.java
@@ -46,4 +46,61 @@ public class BrowseUIControllerJobInfoTest extends AbstractBrowseServiceTest {
         assertNotNull(response.getBody());
         assertFalse(response.getBody().isEmpty());
     }
+
+    @Test
+    void getRunStagesFromJobInfoSuccessTest() {
+        ResponseEntity<String> response =
+            controller.getRunStagesFromJobInfo(
+                TestData.company, TestData.org, TestData.repo, TestData.branch, jobInfoString);
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertFalse(response.getBody().isEmpty());
+    }
+
+    @Test
+    void getTestResultNaturalKeysSuccessTest() {
+        ResponseEntity<String> response =
+            controller.getTestResultNaturalKeys(
+                TestData.company, TestData.org, TestData.repo, TestData.branch,
+                jobInfoString, 1, TestData.stage);
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertFalse(response.getBody().isEmpty());
+    }
+
+    @Test
+    void getLatestRunStagesFromJobInfoMatchesJobIdTest() {
+        ResponseEntity<String> jobInfoResponse =
+            controller.getLatestRunStagesFromJobInfo(
+                TestData.company, TestData.org, TestData.repo, TestData.branch, jobInfoString);
+
+        ResponseEntity<String> jobIdResponse =
+            controller.getLatestRunStages(
+                TestData.company, TestData.org, TestData.repo, TestData.branch, TestData.jobId);
+
+        assertNotNull(jobInfoResponse.getBody());
+        assertNotNull(jobIdResponse.getBody());
+        assertEquals(jobIdResponse.getBody(), jobInfoResponse.getBody());
+    }
+
+    @Test
+    void getLatestRunStageTestResultFromJobInfoMatchesJobIdTest() {
+        ResponseEntity<String> jobInfoResponse =
+            controller.getLatestRunStageTestResultFromJobInfo(
+                TestData.company, TestData.org, TestData.repo, TestData.branch,
+                jobInfoString, TestData.stage);
+
+        ResponseEntity<String> jobIdResponse =
+            controller.getLatestRunStageTestResult(
+                TestData.company, TestData.org, TestData.repo, TestData.branch,
+                TestData.jobId, TestData.stage);
+
+        assertNotNull(jobInfoResponse.getBody());
+        assertNotNull(jobIdResponse.getBody());
+        assertEquals(jobIdResponse.getBody(), jobInfoResponse.getBody());
+    }
 }

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/browse/BrowseUIControllerJobInfoTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/browse/BrowseUIControllerJobInfoTest.java
@@ -1,0 +1,49 @@
+package io.github.ericdriggs.reportcard.controller.browse;
+
+import io.github.ericdriggs.reportcard.gen.db.TestData;
+import io.github.ericdriggs.reportcard.persist.BrowseService;
+import io.github.ericdriggs.reportcard.persist.browse.AbstractBrowseServiceTest;
+import io.github.ericdriggs.reportcard.util.StringMapUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BrowseUIControllerJobInfoTest extends AbstractBrowseServiceTest {
+
+    private final BrowseUIController controller;
+    private final String jobInfoString = StringMapUtil.toEqualsCsv(TestData.jobInfo);
+
+    @Autowired
+    public BrowseUIControllerJobInfoTest(BrowseService browseService, BrowseUIController controller) {
+        super(browseService);
+        this.controller = controller;
+    }
+
+    @Test
+    void getLatestRunStagesFromJobInfoSuccessTest() {
+        ResponseEntity<String> response =
+            controller.getLatestRunStagesFromJobInfo(
+                TestData.company, TestData.org, TestData.repo, TestData.branch, jobInfoString);
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertFalse(response.getBody().isEmpty());
+    }
+
+    @Test
+    void getLatestRunStageTestResultFromJobInfoSuccessTest() {
+        ResponseEntity<String> response =
+            controller.getLatestRunStageTestResultFromJobInfo(
+                TestData.company, TestData.org, TestData.repo, TestData.branch,
+                jobInfoString, TestData.stage);
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertFalse(response.getBody().isEmpty());
+    }
+}

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/graph/GraphJsonControllerJobInfoTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/graph/GraphJsonControllerJobInfoTest.java
@@ -1,0 +1,51 @@
+package io.github.ericdriggs.reportcard.controller.graph;
+
+import io.github.ericdriggs.reportcard.gen.db.TestData;
+import io.github.ericdriggs.reportcard.model.trend.JobStageTestTrend;
+import io.github.ericdriggs.reportcard.persist.BrowseService;
+import io.github.ericdriggs.reportcard.persist.browse.AbstractBrowseServiceTest;
+import io.github.ericdriggs.reportcard.util.StringMapUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class GraphJsonControllerJobInfoTest extends AbstractBrowseServiceTest {
+
+    private final GraphJsonController controller;
+    private final String jobInfoString = StringMapUtil.toEqualsCsv(TestData.jobInfo);
+
+    @Autowired
+    public GraphJsonControllerJobInfoTest(BrowseService browseService, GraphJsonController controller) {
+        super(browseService);
+        this.controller = controller;
+    }
+
+    @Test
+    void getJobStageTestTrendFromJobInfoSuccessTest() {
+        ResponseEntity<JobStageTestTrend> response =
+            controller.getJobStageTestTrendFromJobInfo(
+                TestData.company, TestData.org, TestData.repo, TestData.branch,
+                jobInfoString, TestData.stage, null, null);
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void getJobStageTestTrendFromJobInfoMatchesJobIdTest() {
+        ResponseEntity<JobStageTestTrend> jobInfoResponse =
+            controller.getJobStageTestTrendFromJobInfo(
+                TestData.company, TestData.org, TestData.repo, TestData.branch,
+                jobInfoString, TestData.stage, null, null);
+
+        ResponseEntity<JobStageTestTrend> jobIdResponse =
+            controller.getJobStageTestTrend(
+                TestData.company, TestData.org, TestData.repo, TestData.branch,
+                TestData.jobId, TestData.stage, null, null);
+
+        assertEquals(jobIdResponse.getStatusCode(), jobInfoResponse.getStatusCode());
+    }
+}

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/graph/GraphJsonControllerJobInfoTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/graph/GraphJsonControllerJobInfoTest.java
@@ -32,6 +32,9 @@ public class GraphJsonControllerJobInfoTest extends AbstractBrowseServiceTest {
 
         assertNotNull(response);
         assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertNotNull(response.getBody().getTestCaseTrends());
+        assertFalse(response.getBody().getTestCaseTrends().isEmpty());
     }
 
     @Test
@@ -47,5 +50,13 @@ public class GraphJsonControllerJobInfoTest extends AbstractBrowseServiceTest {
                 TestData.jobId, TestData.stage, null, null);
 
         assertEquals(jobIdResponse.getStatusCode(), jobInfoResponse.getStatusCode());
+        assertNotNull(jobInfoResponse.getBody());
+        assertNotNull(jobIdResponse.getBody());
+        assertEquals(
+            jobIdResponse.getBody().getCompanyOrgRepoBranchJobStageName(),
+            jobInfoResponse.getBody().getCompanyOrgRepoBranchJobStageName());
+        assertEquals(
+            jobIdResponse.getBody().getTestCaseTrends().size(),
+            jobInfoResponse.getBody().getTestCaseTrends().size());
     }
 }

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/graph/GraphUIControllerJobInfoTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/graph/GraphUIControllerJobInfoTest.java
@@ -1,0 +1,51 @@
+package io.github.ericdriggs.reportcard.controller.graph;
+
+import io.github.ericdriggs.reportcard.gen.db.TestData;
+import io.github.ericdriggs.reportcard.persist.BrowseService;
+import io.github.ericdriggs.reportcard.persist.browse.AbstractBrowseServiceTest;
+import io.github.ericdriggs.reportcard.util.StringMapUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class GraphUIControllerJobInfoTest extends AbstractBrowseServiceTest {
+
+    private final GraphUIController controller;
+    private final String jobInfoString = StringMapUtil.toEqualsCsv(TestData.jobInfo);
+
+    @Autowired
+    public GraphUIControllerJobInfoTest(BrowseService browseService, GraphUIController controller) {
+        super(browseService);
+        this.controller = controller;
+    }
+
+    @Test
+    void getJobStageTestTrendFromJobInfoSuccessTest() {
+        ResponseEntity<String> response =
+            controller.getJobStageTestTrendFromJobInfo(
+                TestData.company, TestData.org, TestData.repo, TestData.branch,
+                jobInfoString, TestData.stage, null, null, 30);
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+    }
+
+    @Test
+    void getJobStageTestTrendFromJobInfoMatchesJobIdTest() {
+        ResponseEntity<String> jobInfoResponse =
+            controller.getJobStageTestTrendFromJobInfo(
+                TestData.company, TestData.org, TestData.repo, TestData.branch,
+                jobInfoString, TestData.stage, null, null, 30);
+
+        ResponseEntity<String> jobIdResponse =
+            controller.getJobStageTestTrend(
+                TestData.company, TestData.org, TestData.repo, TestData.branch,
+                TestData.jobId, TestData.stage, null, null, 30);
+
+        assertEquals(jobIdResponse.getStatusCode(), jobInfoResponse.getStatusCode());
+    }
+}

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/graph/GraphUIControllerJobInfoTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/graph/GraphUIControllerJobInfoTest.java
@@ -32,6 +32,7 @@ public class GraphUIControllerJobInfoTest extends AbstractBrowseServiceTest {
         assertNotNull(response);
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
+        assertFalse(response.getBody().isEmpty());
     }
 
     @Test
@@ -47,5 +48,8 @@ public class GraphUIControllerJobInfoTest extends AbstractBrowseServiceTest {
                 TestData.jobId, TestData.stage, null, null, 30);
 
         assertEquals(jobIdResponse.getStatusCode(), jobInfoResponse.getStatusCode());
+        assertNotNull(jobInfoResponse.getBody());
+        assertNotNull(jobIdResponse.getBody());
+        assertEquals(jobIdResponse.getBody(), jobInfoResponse.getBody());
     }
 }


### PR DESCRIPTION
## Summary

  - Every job-scoped endpoint that previously required the internal `jobId` (Long PK) now has a corresponding `jobInfo` variant using the natural key
   (e.g., `application=fooapp,host=foocorp.jenkins.com,pipeline=foopipeline`)
  - Controllers updated: BrowseJsonController (5 new), BrowseUIController (2 new), GraphJsonController (1 new), GraphUIController (1 new)
  - Each jobInfo endpoint resolves the natural key via `browseService.getJob()` then delegates to the existing jobId method

  ## Motivation

  API consumers (CI pipelines, dashboards) know their job's natural key but not the internal surrogate ID. Previously they had to look up the jobId
  first, adding an extra round-trip. Now all job-scoped operations are directly accessible by natural key.

  ## New endpoints

  | Controller | Path |
  |---|---|
  | BrowseJsonController | `company/{company}/org/{org}/repo/{repo}/branch/{branch}/jobinfo/{jobInfo}/run` |
  | BrowseJsonController | `company/{company}/org/{org}/repo/{repo}/branch/{branch}/jobinfo/{jobInfo}/runcount/{runCount}` |
  | BrowseJsonController | `company/{company}/org/{org}/repo/{repo}/branch/{branch}/jobinfo/{jobInfo}/run/latest` |
  | BrowseJsonController | `company/{company}/org/{org}/repo/{repo}/branch/{branch}/jobinfo/{jobInfo}/runcount/{runCount}/stage/{stage}` |
  | BrowseJsonController | `company/{company}/org/{org}/repo/{repo}/branch/{branch}/jobinfo/{jobInfo}/run/latest/stage/{stage}` |
  | BrowseUIController | `company/{company}/org/{org}/repo/{repo}/branch/{branch}/jobinfo/{jobInfo}/run/latest` |
  | BrowseUIController | `company/{company}/org/{org}/repo/{repo}/branch/{branch}/jobinfo/{jobInfo}/run/latest/stage/{stage}` |
  | GraphJsonController | `company/{company}/org/{org}/repo/{repo}/branch/{branch}/jobinfo/{jobInfo}/stage/{stage}/trend` |
  | GraphUIController | `company/{company}/org/{org}/repo/{repo}/branch/{branch}/jobinfo/{jobInfo}/stage/{stage}/trend` |

  ## Test plan

  - [x] 20 new tests across 4 test files covering success and equivalence with jobId variants
  - [x] Equivalence tests verify runcount-based endpoints return same data as latest-run endpoints
  - [x] Graph controller tests verify body content (not just status codes)
  - [x] Full test suite passes with no regressions
  - [x] Manual validation against live local server confirmed all endpoints return expected data