### PR TITLE
Org dashboard flat endpoint

### DIFF
--- a/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/controller/browse/BrowseJsonController.java
+++ b/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/controller/browse/BrowseJsonController.java
@@ -117,6 +117,19 @@ public class BrowseJsonController {
         return new ResponseEntity<>(orgDashboard, HttpStatus.OK);
     }
 
+    @GetMapping(path = "company/{company}/org/{org}/dashboard/flat", produces = "application/json")
+    public ResponseEntity<List<FlatDashboardEntry>> getOrgDashboardFlatJson(
+            @PathVariable String company,
+            @PathVariable String org,
+            @RequestParam(required = false) List<String> repos,
+            @RequestParam(required = false, defaultValue = "") List<String> branches,
+            @RequestParam(required = false, defaultValue = "true") boolean shouldIncludeDefaultBranches,
+            @RequestParam(required = false) Integer days
+    ) {
+        OrgDashboard orgDashboard = graphService.getOrgDashboard(company, org, repos, branches, shouldIncludeDefaultBranches, validateDays(days));
+        return new ResponseEntity<>(OrgDashboardFlattener.flatten(List.of(orgDashboard)), HttpStatus.OK);
+    }
+
     @GetMapping(path = {"company/{company}/org/{org}/repo/{repo}", "org/{org}/repo/{repo}/branch"}, produces = "application/json")
     public ResponseEntity<RepoBranchesJobsResponse> getRepoBranchesJobs(
             @PathVariable String company,

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/browse/BrowseJsonControllerFlatDashboardTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/browse/BrowseJsonControllerFlatDashboardTest.java
@@ -143,4 +143,35 @@ public class BrowseJsonControllerFlatDashboardTest extends AbstractBrowseService
         assertNotNull(response.getBody());
         assertTrue(response.getBody().isEmpty());
     }
+
+    @Test
+    void getOrgDashboardFlatJsonSuccessTest() {
+        ResponseEntity<List<FlatDashboardEntry>> response =
+            controller.getOrgDashboardFlatJson(
+                TestData.company, TestData.org,
+                null, new java.util.ArrayList<>(), true, null);
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertFalse(response.getBody().isEmpty());
+
+        FlatDashboardEntry first = response.getBody().get(0);
+        assertEquals(TestData.company, first.getCompany());
+        assertEquals(TestData.org, first.getOrg());
+        assertNotNull(first.getRepo());
+        assertNotNull(first.getBranch());
+        assertNotNull(first.getJobId());
+        assertNotNull(first.getJobInfo());
+        assertNotNull(first.getRunId());
+        assertNotNull(first.getJobRunCount());
+        assertNotNull(first.getSha());
+        assertNotNull(first.getRunDate());
+        assertNotNull(first.getIsSuccess());
+        assertNotNull(first.getUrl());
+        assertTrue(first.getUrl().contains("/company/"));
+        assertTrue(first.getUrl().contains("/run/"));
+        assertNotNull(first.getStageName());
+        assertNotNull(first.getStorageUrls());
+    }
 }


### PR DESCRIPTION
## Summary

- Add `GET /json/company/{company}/org/{org}/dashboard/flat` endpoint that returns `List<FlatDashboardEntry>` — the denormalized equivalent of the existing nested org dashboard endpoint
- Reuses existing `GraphService.getOrgDashboard()` and `OrgDashboardFlattener.flatten()` with no new service/persist layer changes

## Test plan

- [x] New integration test `getOrgDashboardFlatJsonSuccessTest` verifies non-empty response with all fields populated and correct company/org context
- [x] All existing flat dashboard tests pass (no regressions)
- [x] Full `reportcard-server` test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)