### PR TITLE
Prevent XSS injection and filter empty jobs from dashboard

### DIFF
--- a/reportcard-model/src/test/java/io/github/ericdriggs/reportcard/util/StringMapUtilTest.java
+++ b/reportcard-model/src/test/java/io/github/ericdriggs/reportcard/util/StringMapUtilTest.java
@@ -35,9 +35,9 @@ public class StringMapUtilTest {
 
     @Test
     void preservesUnderscoresAndDigits() {
-        TreeMap<String, String> map = StringMapUtil.stringToMap("env=prod_us-east-1,pipeline=dev-cp3");
+        TreeMap<String, String> map = StringMapUtil.stringToMap("env=prod_us-east-1,pipeline=release-candidate");
         assertEquals("prod_us-east-1", map.get("env"));
-        assertEquals("dev-cp3", map.get("pipeline"));
+        assertEquals("release-candidate", map.get("pipeline"));
     }
 
 }

--- a/reportcard-model/src/test/java/io/github/ericdriggs/reportcard/util/StringMapUtilTest.java
+++ b/reportcard-model/src/test/java/io/github/ericdriggs/reportcard/util/StringMapUtilTest.java
@@ -26,4 +26,18 @@ public class StringMapUtilTest {
         assertEquals("baz1", map.get("BAZ"));
     }
 
+    @Test
+    void preservesHyphensAndDots() {
+        TreeMap<String, String> map = StringMapUtil.stringToMap("application=foo-app,host=build.corp.jenkins.com");
+        assertEquals("foo-app", map.get("application"));
+        assertEquals("build.corp.jenkins.com", map.get("host"));
+    }
+
+    @Test
+    void preservesUnderscoresAndDigits() {
+        TreeMap<String, String> map = StringMapUtil.stringToMap("env=prod_us-east-1,pipeline=dev-cp3");
+        assertEquals("prod_us-east-1", map.get("env"));
+        assertEquals("dev-cp3", map.get("pipeline"));
+    }
+
 }

--- a/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/controller/graph/OrgDashboardHtmlHelper.java
+++ b/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/controller/graph/OrgDashboardHtmlHelper.java
@@ -77,6 +77,9 @@ public class OrgDashboardHtmlHelper extends BrowseHtmlHelper {
                     if (CollectionUtils.isEmpty(jobGraph.jobInfo())) {
                         continue;
                     }
+                    if (CollectionUtils.isEmpty(jobGraph.runs())) {
+                        continue;
+                    }
                     final CompanyOrgRepoBranchJobRunStageDTO jobPath = branchPath.toBuilder().jobId(jobGraph.jobId()).build();
                     final String jobUrl = getUrl(jobPath);
                     final String jobInfoTruncated = TruncateUtils.truncateRight(StringMapUtil.valuesOnlyColonSeparated(jobGraph.jobInfo()), 45, true);

--- a/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/model/StageDetails.java
+++ b/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/model/StageDetails.java
@@ -65,10 +65,30 @@ public class StageDetails {
             addErrorIfMissing(errors, stage, "stage");
             jobInfo = lower(jobInfo);
             branch = branch.replace("/", "_");
+            company = stripHtmlChars(company);
+            org = stripHtmlChars(org);
+            repo = stripHtmlChars(repo);
+            branch = stripHtmlChars(branch);
+            stage = stripHtmlChars(stage);
+            jobInfo = stripHtmlCharsFromMap(jobInfo);
             if (!errors.isEmpty()) {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
                         "errors - " + Arrays.toString(errors.entrySet().toArray()));
             }
+        }
+
+        private static String stripHtmlChars(String input) {
+            if (input == null) return null;
+            return input.replaceAll("[<>\"'&]", "");
+        }
+
+        private static TreeMap<String, String> stripHtmlCharsFromMap(TreeMap<String, String> map) {
+            if (map == null || map.isEmpty()) return map;
+            TreeMap<String, String> result = new TreeMap<>();
+            for (Map.Entry<String, String> entry : map.entrySet()) {
+                result.put(stripHtmlChars(entry.getKey()), stripHtmlChars(entry.getValue()));
+            }
+            return result;
         }
 
         @JsonIgnore

--- a/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/model/StageDetails.java
+++ b/reportcard-server/src/main/java/io/github/ericdriggs/reportcard/model/StageDetails.java
@@ -56,6 +56,17 @@ public class StageDetails {
             if (runReference == null) {
                 runReference = UUID.randomUUID();
             }
+            jobInfo = lower(jobInfo);
+            if (branch != null) {
+                branch = branch.replace("/", "_");
+            }
+            company = stripHtmlChars(company);
+            org = stripHtmlChars(org);
+            repo = stripHtmlChars(repo);
+            branch = stripHtmlChars(branch);
+            sha = stripHtmlChars(sha);
+            stage = stripHtmlChars(stage);
+            jobInfo = stripHtmlCharsFromMap(jobInfo);
             Map<String, String> errors = new LinkedHashMap<>();
             addErrorIfMissing(errors, company, "company");
             addErrorIfMissing(errors, org, "org");
@@ -63,14 +74,6 @@ public class StageDetails {
             addErrorIfMissing(errors, branch, "branch");
             addErrorIfMissing(errors, sha, "sha");
             addErrorIfMissing(errors, stage, "stage");
-            jobInfo = lower(jobInfo);
-            branch = branch.replace("/", "_");
-            company = stripHtmlChars(company);
-            org = stripHtmlChars(org);
-            repo = stripHtmlChars(repo);
-            branch = stripHtmlChars(branch);
-            stage = stripHtmlChars(stage);
-            jobInfo = stripHtmlCharsFromMap(jobInfo);
             if (!errors.isEmpty()) {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
                         "errors - " + Arrays.toString(errors.entrySet().toArray()));

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/JunitControllerTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/JunitControllerTest.java
@@ -64,7 +64,7 @@ public class JunitControllerTest {
     private TestResultPersistService testResultPersistService;
 
     @Test
-    void jobInfoHtmlCharsStrippedOnIngestion() {
+    void stageDetailsStripsHtmlCharsFromJobInfo() {
         TreeMap<String, String> maliciousJobInfo = new TreeMap<>();
         maliciousJobInfo.put("application", "<script>xss</script>");
         maliciousJobInfo.put("pipeline", "foo&bar");

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/JunitControllerTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/JunitControllerTest.java
@@ -31,10 +31,7 @@ import software.amazon.awssdk.services.s3.model.S3Object;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -65,6 +62,27 @@ public class JunitControllerTest {
 
     @Autowired
     private TestResultPersistService testResultPersistService;
+
+    @Test
+    void jobInfoHtmlCharsStrippedOnIngestion() {
+        TreeMap<String, String> maliciousJobInfo = new TreeMap<>();
+        maliciousJobInfo.put("application", "<script>xss</script>");
+        maliciousJobInfo.put("pipeline", "foo&bar");
+
+        StageDetails stageDetails = StageDetails.builder()
+                .company(TestData.company)
+                .org(TestData.org)
+                .repo(TestData.repo)
+                .branch(TestData.branch)
+                .sha(TestData.sha)
+                .jobInfo(maliciousJobInfo)
+                .runReference(UUID.randomUUID())
+                .stage("htmlStripTest")
+                .build();
+
+        assertEquals("scriptxss/script", stageDetails.getJobInfo().get("application"));
+        assertEquals("foobar", stageDetails.getJobInfo().get("pipeline"));
+    }
 
     static StageDetails getStageDetails(String stageName) {
         return StageDetails.builder()

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/browse/BrowseJsonControllerJobInfoTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/browse/BrowseJsonControllerJobInfoTest.java
@@ -44,7 +44,7 @@ public class BrowseJsonControllerJobInfoTest extends AbstractBrowseServiceTest {
 
     @Test
     void jobInfoPreservesSpecialCharsTest() {
-        String realisticJobInfo = "application=foo-app,host=build.corp.jenkins.com,pipeline=dev_cp-3";
+        String realisticJobInfo = "application=foo-app,host=build.corp.jenkins.com,pipeline=re-lease_candidate";
         org.springframework.web.server.ResponseStatusException ex = assertThrows(
             org.springframework.web.server.ResponseStatusException.class,
             () -> controller.getJobRunsStagesFromJobInfo(
@@ -52,7 +52,7 @@ public class BrowseJsonControllerJobInfoTest extends AbstractBrowseServiceTest {
         assertEquals(org.springframework.http.HttpStatus.NOT_FOUND, ex.getStatus());
         assertTrue(ex.getReason().contains("foo-app"));
         assertTrue(ex.getReason().contains("build.corp.jenkins.com"));
-        assertTrue(ex.getReason().contains("dev_cp-3"));
+        assertTrue(ex.getReason().contains("re-lease_candidate"));
     }
 
     @Test

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/browse/BrowseJsonControllerJobInfoTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/browse/BrowseJsonControllerJobInfoTest.java
@@ -43,6 +43,19 @@ public class BrowseJsonControllerJobInfoTest extends AbstractBrowseServiceTest {
     }
 
     @Test
+    void jobInfoPreservesSpecialCharsTest() {
+        String realisticJobInfo = "application=foo-app,host=build.corp.jenkins.com,pipeline=dev_cp-3";
+        org.springframework.web.server.ResponseStatusException ex = assertThrows(
+            org.springframework.web.server.ResponseStatusException.class,
+            () -> controller.getJobRunsStagesFromJobInfo(
+                TestData.company, TestData.org, TestData.repo, TestData.branch, realisticJobInfo, null));
+        assertEquals(org.springframework.http.HttpStatus.NOT_FOUND, ex.getStatus());
+        assertTrue(ex.getReason().contains("foo-app"));
+        assertTrue(ex.getReason().contains("build.corp.jenkins.com"));
+        assertTrue(ex.getReason().contains("dev_cp-3"));
+    }
+
+    @Test
     void getJobRunsStagesFromJobInfoMatchesJobIdTest() {
         ResponseEntity<JobRunsStagesResponse> jobInfoResponse =
             controller.getJobRunsStagesFromJobInfo(

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/browse/BrowseJsonControllerTrendTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/browse/BrowseJsonControllerTrendTest.java
@@ -69,7 +69,7 @@ public class BrowseJsonControllerTrendTest extends AbstractBrowseServiceTest {
 
     @Test
     void trendJobInfoPreservesSpecialCharsTest() {
-        String realisticJobInfo = "application=foo-app,host=build.corp.jenkins.com,pipeline=dev_cp-3";
+        String realisticJobInfo = "application=foo-app,host=build.corp.jenkins.com,pipeline=re-lease_candidate";
         org.springframework.web.server.ResponseStatusException ex = assertThrows(
             org.springframework.web.server.ResponseStatusException.class,
             () -> controller.getJobStageTestTrendFromJobInfoJson(
@@ -78,7 +78,7 @@ public class BrowseJsonControllerTrendTest extends AbstractBrowseServiceTest {
         assertEquals(org.springframework.http.HttpStatus.NOT_FOUND, ex.getStatus());
         assertTrue(ex.getReason().contains("foo-app"));
         assertTrue(ex.getReason().contains("build.corp.jenkins.com"));
-        assertTrue(ex.getReason().contains("dev_cp-3"));
+        assertTrue(ex.getReason().contains("re-lease_candidate"));
     }
 
     @Test

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/browse/BrowseJsonControllerTrendTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/browse/BrowseJsonControllerTrendTest.java
@@ -68,6 +68,20 @@ public class BrowseJsonControllerTrendTest extends AbstractBrowseServiceTest {
     }
 
     @Test
+    void trendJobInfoPreservesSpecialCharsTest() {
+        String realisticJobInfo = "application=foo-app,host=build.corp.jenkins.com,pipeline=dev_cp-3";
+        org.springframework.web.server.ResponseStatusException ex = assertThrows(
+            org.springframework.web.server.ResponseStatusException.class,
+            () -> controller.getJobStageTestTrendFromJobInfoJson(
+                TestData.company, TestData.org, TestData.repo, TestData.branch,
+                realisticJobInfo, TestData.stage, null, null, 30, TrendDetail.full, false));
+        assertEquals(org.springframework.http.HttpStatus.NOT_FOUND, ex.getStatus());
+        assertTrue(ex.getReason().contains("foo-app"));
+        assertTrue(ex.getReason().contains("build.corp.jenkins.com"));
+        assertTrue(ex.getReason().contains("dev_cp-3"));
+    }
+
+    @Test
     void getJobStageTestTrendJsonEmptyResultTest() {
         // Non-existent job should return empty response
         ResponseEntity<TestTrendResponse> response = controller.getJobStageTestTrendJson(

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/browse/BrowseUIControllerJobInfoTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/browse/BrowseUIControllerJobInfoTest.java
@@ -74,7 +74,7 @@ public class BrowseUIControllerJobInfoTest extends AbstractBrowseServiceTest {
 
     @Test
     void jobInfoPreservesSpecialCharsTest() {
-        String realisticJobInfo = "application=foo-app,host=build.corp.jenkins.com,pipeline=dev_cp-3";
+        String realisticJobInfo = "application=foo-app,host=build.corp.jenkins.com,pipeline=re-lease_candidate";
         org.springframework.web.server.ResponseStatusException ex = assertThrows(
             org.springframework.web.server.ResponseStatusException.class,
             () -> controller.getLatestRunStagesFromJobInfo(
@@ -82,7 +82,7 @@ public class BrowseUIControllerJobInfoTest extends AbstractBrowseServiceTest {
         assertEquals(org.springframework.http.HttpStatus.NOT_FOUND, ex.getStatus());
         assertTrue(ex.getReason().contains("foo-app"));
         assertTrue(ex.getReason().contains("build.corp.jenkins.com"));
-        assertTrue(ex.getReason().contains("dev_cp-3"));
+        assertTrue(ex.getReason().contains("re-lease_candidate"));
     }
 
     @Test

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/browse/BrowseUIControllerJobInfoTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/browse/BrowseUIControllerJobInfoTest.java
@@ -73,6 +73,19 @@ public class BrowseUIControllerJobInfoTest extends AbstractBrowseServiceTest {
     }
 
     @Test
+    void jobInfoPreservesSpecialCharsTest() {
+        String realisticJobInfo = "application=foo-app,host=build.corp.jenkins.com,pipeline=dev_cp-3";
+        org.springframework.web.server.ResponseStatusException ex = assertThrows(
+            org.springframework.web.server.ResponseStatusException.class,
+            () -> controller.getLatestRunStagesFromJobInfo(
+                TestData.company, TestData.org, TestData.repo, TestData.branch, realisticJobInfo));
+        assertEquals(org.springframework.http.HttpStatus.NOT_FOUND, ex.getStatus());
+        assertTrue(ex.getReason().contains("foo-app"));
+        assertTrue(ex.getReason().contains("build.corp.jenkins.com"));
+        assertTrue(ex.getReason().contains("dev_cp-3"));
+    }
+
+    @Test
     void getLatestRunStagesFromJobInfoMatchesJobIdTest() {
         ResponseEntity<String> jobInfoResponse =
             controller.getLatestRunStagesFromJobInfo(

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/graph/GraphJsonControllerJobInfoTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/graph/GraphJsonControllerJobInfoTest.java
@@ -39,7 +39,7 @@ public class GraphJsonControllerJobInfoTest extends AbstractBrowseServiceTest {
 
     @Test
     void jobInfoPreservesSpecialCharsTest() {
-        String realisticJobInfo = "application=foo-app,host=build.corp.jenkins.com,pipeline=dev_cp-3";
+        String realisticJobInfo = "application=foo-app,host=build.corp.jenkins.com,pipeline=re-lease_candidate";
         // Parsing succeeds; 404 means lookup ran but no match — not a parse failure
         org.springframework.web.server.ResponseStatusException ex = assertThrows(
             org.springframework.web.server.ResponseStatusException.class,
@@ -49,7 +49,7 @@ public class GraphJsonControllerJobInfoTest extends AbstractBrowseServiceTest {
         assertEquals(org.springframework.http.HttpStatus.NOT_FOUND, ex.getStatus());
         assertTrue(ex.getReason().contains("foo-app"));
         assertTrue(ex.getReason().contains("build.corp.jenkins.com"));
-        assertTrue(ex.getReason().contains("dev_cp-3"));
+        assertTrue(ex.getReason().contains("re-lease_candidate"));
     }
 
     @Test

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/graph/GraphJsonControllerJobInfoTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/graph/GraphJsonControllerJobInfoTest.java
@@ -38,6 +38,21 @@ public class GraphJsonControllerJobInfoTest extends AbstractBrowseServiceTest {
     }
 
     @Test
+    void jobInfoPreservesSpecialCharsTest() {
+        String realisticJobInfo = "application=foo-app,host=build.corp.jenkins.com,pipeline=dev_cp-3";
+        // Parsing succeeds; 404 means lookup ran but no match — not a parse failure
+        org.springframework.web.server.ResponseStatusException ex = assertThrows(
+            org.springframework.web.server.ResponseStatusException.class,
+            () -> controller.getJobStageTestTrendFromJobInfo(
+                TestData.company, TestData.org, TestData.repo, TestData.branch,
+                realisticJobInfo, TestData.stage, null, null));
+        assertEquals(org.springframework.http.HttpStatus.NOT_FOUND, ex.getStatus());
+        assertTrue(ex.getReason().contains("foo-app"));
+        assertTrue(ex.getReason().contains("build.corp.jenkins.com"));
+        assertTrue(ex.getReason().contains("dev_cp-3"));
+    }
+
+    @Test
     void getJobStageTestTrendFromJobInfoMatchesJobIdTest() {
         ResponseEntity<JobStageTestTrend> jobInfoResponse =
             controller.getJobStageTestTrendFromJobInfo(

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/graph/GraphUIControllerJobInfoTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/graph/GraphUIControllerJobInfoTest.java
@@ -36,6 +36,20 @@ public class GraphUIControllerJobInfoTest extends AbstractBrowseServiceTest {
     }
 
     @Test
+    void jobInfoPreservesSpecialCharsTest() {
+        String realisticJobInfo = "application=foo-app,host=build.corp.jenkins.com,pipeline=dev_cp-3";
+        org.springframework.web.server.ResponseStatusException ex = assertThrows(
+            org.springframework.web.server.ResponseStatusException.class,
+            () -> controller.getJobStageTestTrendFromJobInfo(
+                TestData.company, TestData.org, TestData.repo, TestData.branch,
+                realisticJobInfo, TestData.stage, null, null, 30));
+        assertEquals(org.springframework.http.HttpStatus.NOT_FOUND, ex.getStatus());
+        assertTrue(ex.getReason().contains("foo-app"));
+        assertTrue(ex.getReason().contains("build.corp.jenkins.com"));
+        assertTrue(ex.getReason().contains("dev_cp-3"));
+    }
+
+    @Test
     void getJobStageTestTrendFromJobInfoMatchesJobIdTest() {
         ResponseEntity<String> jobInfoResponse =
             controller.getJobStageTestTrendFromJobInfo(

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/graph/GraphUIControllerJobInfoTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/graph/GraphUIControllerJobInfoTest.java
@@ -37,7 +37,7 @@ public class GraphUIControllerJobInfoTest extends AbstractBrowseServiceTest {
 
     @Test
     void jobInfoPreservesSpecialCharsTest() {
-        String realisticJobInfo = "application=foo-app,host=build.corp.jenkins.com,pipeline=dev_cp-3";
+        String realisticJobInfo = "application=foo-app,host=build.corp.jenkins.com,pipeline=re-lease_candidate";
         org.springframework.web.server.ResponseStatusException ex = assertThrows(
             org.springframework.web.server.ResponseStatusException.class,
             () -> controller.getJobStageTestTrendFromJobInfo(
@@ -46,7 +46,7 @@ public class GraphUIControllerJobInfoTest extends AbstractBrowseServiceTest {
         assertEquals(org.springframework.http.HttpStatus.NOT_FOUND, ex.getStatus());
         assertTrue(ex.getReason().contains("foo-app"));
         assertTrue(ex.getReason().contains("build.corp.jenkins.com"));
-        assertTrue(ex.getReason().contains("dev_cp-3"));
+        assertTrue(ex.getReason().contains("re-lease_candidate"));
     }
 
     @Test

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/graph/JobDashboardEndpointsIntegrationTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/graph/JobDashboardEndpointsIntegrationTest.java
@@ -36,7 +36,7 @@ public class JobDashboardEndpointsIntegrationTest {
     @Test
     public void testJobDashboardUIEndpointWithJobInfo() {
         ResponseEntity<String> response = graphUIController.getJobDashboard("hulu", "SubLife", 
-                List.of("pipeline:dev-cp3"), 90);
+                List.of("pipeline:release-candidate"), 90);
         assertEquals(200, response.getStatusCodeValue());
         assertNotNull(response.getBody());
     }
@@ -66,7 +66,7 @@ public class JobDashboardEndpointsIntegrationTest {
     @Test
     public void testJobDashboardJsonEndpointWithJobInfo() {
         ResponseEntity<List<JobDashboardMetrics>> response = graphJsonController.getJobDashboardJson("hulu", "SubLife", 
-                List.of("pipeline:dev-cp3"), 90);
+                List.of("pipeline:release-candidate"), 90);
         assertEquals(200, response.getStatusCodeValue());
         assertNotNull(response.getBody());
     }

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/graph/JobInfoParserTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/graph/JobInfoParserTest.java
@@ -29,10 +29,10 @@ class JobInfoParserTest {
 
     @Test
     void testNoWildcard() {
-        List<String> jobInfo = Arrays.asList("pipeline:dev-cp3");
+        List<String> jobInfo = Arrays.asList("pipeline:release-candidate");
         Map<String, String> result = JobInfoParser.parseJobInfoParams(jobInfo);
         
-        assertEquals("dev-cp3", result.get("pipeline"));
+        assertEquals("release-candidate", result.get("pipeline"));
     }
 
     @Test

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/graph/JobInfoWildcardIntegrationTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/controller/graph/JobInfoWildcardIntegrationTest.java
@@ -53,7 +53,7 @@ public class JobInfoWildcardIntegrationTest {
     @Test
     public void testExactMatch() {
         ResponseEntity<List<JobDashboardMetrics>> response = graphJsonController.getJobDashboardJson("hulu", "SubLife",
-                List.of("pipeline:dev-cp3"), 90);
+                List.of("pipeline:release-candidate"), 90);
         assertEquals(200, response.getStatusCodeValue());
         assertNotNull(response.getBody());
     }

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/model/StageDetailsTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/model/StageDetailsTest.java
@@ -98,7 +98,7 @@ public class StageDetailsTest {
         TreeMap<String, String> jobInfoMap = new TreeMap<>();
         jobInfoMap.put("application", "foo-app");
         jobInfoMap.put("host", "build.corp.jenkins.com");
-        jobInfoMap.put("pipeline", "dev-cp3");
+        jobInfoMap.put("pipeline", "release-candidate");
         jobInfoMap.put("env", "prod_us-east-1");
 
         StageDetails stageDetails = StageDetails.builder()
@@ -108,7 +108,7 @@ public class StageDetailsTest {
 
         assertEquals("foo-app", stageDetails.getJobInfo().get("application"));
         assertEquals("build.corp.jenkins.com", stageDetails.getJobInfo().get("host"));
-        assertEquals("dev-cp3", stageDetails.getJobInfo().get("pipeline"));
+        assertEquals("release-candidate", stageDetails.getJobInfo().get("pipeline"));
         assertEquals("prod_us-east-1", stageDetails.getJobInfo().get("env"));
     }
 }

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/model/StageDetailsTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/model/StageDetailsTest.java
@@ -34,6 +34,7 @@ public class StageDetailsTest {
         TreeMap<String, String> jobInfoMap = new TreeMap<>();
         jobInfoMap.put("application", "<script>alert(1)</script>");
         jobInfoMap.put("pipeline", "foo&bar");
+        jobInfoMap.put("<img>", "malicious-key");
 
         StageDetails stageDetails = StageDetails.builder()
                 .company(TestData.company).org(TestData.org).repo(TestData.repo)
@@ -42,6 +43,7 @@ public class StageDetailsTest {
 
         assertEquals("scriptalert(1)/script", stageDetails.getJobInfo().get("application"));
         assertEquals("foobar", stageDetails.getJobInfo().get("pipeline"));
+        assertEquals("malicious-key", stageDetails.getJobInfo().get("img"));
     }
 
     @Test
@@ -76,6 +78,19 @@ public class StageDetailsTest {
         assertEquals("my.repo", stageDetails.getRepo());
         assertEquals("feature_my-branch", stageDetails.getBranch());
         assertEquals("unit-tests_v2", stageDetails.getStage());
+    }
+
+    @Test
+    void shaStripsHtmlChars() {
+        TreeMap<String, String> jobInfoMap = new TreeMap<>();
+        jobInfoMap.put("pipeline", "safe");
+
+        StageDetails stageDetails = StageDetails.builder()
+                .company(TestData.company).org(TestData.org).repo(TestData.repo)
+                .branch(TestData.branch).sha("abc<script>123").stage(TestData.stage)
+                .jobInfo(jobInfoMap).build();
+
+        assertEquals("abcscript123", stageDetails.getSha());
     }
 
     @Test

--- a/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/model/StageDetailsTest.java
+++ b/reportcard-server/src/test/java/io/github/ericdriggs/reportcard/model/StageDetailsTest.java
@@ -28,4 +28,72 @@ public class StageDetailsTest {
                 .build();
         assertEquals("{\"application\":\"application1\",\"host\":\"host1\",\"pipeline\":\"pipeline1\"}", stageDetails.getJobInfoJson());
     }
+
+    @Test
+    void jobInfoStripsHtmlChars() {
+        TreeMap<String, String> jobInfoMap = new TreeMap<>();
+        jobInfoMap.put("application", "<script>alert(1)</script>");
+        jobInfoMap.put("pipeline", "foo&bar");
+
+        StageDetails stageDetails = StageDetails.builder()
+                .company(TestData.company).org(TestData.org).repo(TestData.repo)
+                .branch(TestData.branch).sha(TestData.sha).stage(TestData.stage)
+                .jobInfo(jobInfoMap).build();
+
+        assertEquals("scriptalert(1)/script", stageDetails.getJobInfo().get("application"));
+        assertEquals("foobar", stageDetails.getJobInfo().get("pipeline"));
+    }
+
+    @Test
+    void entityNamesStripHtmlChars() {
+        TreeMap<String, String> jobInfoMap = new TreeMap<>();
+        jobInfoMap.put("pipeline", "safe");
+
+        StageDetails stageDetails = StageDetails.builder()
+                .company("my<company").org("my>org").repo("my\"repo")
+                .branch("my'branch").sha(TestData.sha).stage("my&stage")
+                .jobInfo(jobInfoMap).build();
+
+        assertEquals("mycompany", stageDetails.getCompany());
+        assertEquals("myorg", stageDetails.getOrg());
+        assertEquals("myrepo", stageDetails.getRepo());
+        assertEquals("mybranch", stageDetails.getBranch());
+        assertEquals("mystage", stageDetails.getStage());
+    }
+
+    @Test
+    void entityNamesPreserveSlashesHyphensUnderscores() {
+        TreeMap<String, String> jobInfoMap = new TreeMap<>();
+        jobInfoMap.put("pipeline", "my-pipeline");
+
+        StageDetails stageDetails = StageDetails.builder()
+                .company("my-company").org("my_org").repo("my.repo")
+                .branch("feature/my-branch").sha(TestData.sha).stage("unit-tests_v2")
+                .jobInfo(jobInfoMap).build();
+
+        assertEquals("my-company", stageDetails.getCompany());
+        assertEquals("my_org", stageDetails.getOrg());
+        assertEquals("my.repo", stageDetails.getRepo());
+        assertEquals("feature_my-branch", stageDetails.getBranch());
+        assertEquals("unit-tests_v2", stageDetails.getStage());
+    }
+
+    @Test
+    void jobInfoPreservesHyphensDotsUnderscores() {
+        TreeMap<String, String> jobInfoMap = new TreeMap<>();
+        jobInfoMap.put("application", "foo-app");
+        jobInfoMap.put("host", "build.corp.jenkins.com");
+        jobInfoMap.put("pipeline", "dev-cp3");
+        jobInfoMap.put("env", "prod_us-east-1");
+
+        StageDetails stageDetails = StageDetails.builder()
+                .company(TestData.company).org(TestData.org).repo(TestData.repo)
+                .branch(TestData.branch).sha(TestData.sha).stage(TestData.stage)
+                .jobInfo(jobInfoMap).build();
+
+        assertEquals("foo-app", stageDetails.getJobInfo().get("application"));
+        assertEquals("build.corp.jenkins.com", stageDetails.getJobInfo().get("host"));
+        assertEquals("dev-cp3", stageDetails.getJobInfo().get("pipeline"));
+        assertEquals("prod_us-east-1", stageDetails.getJobInfo().get("env"));
+    }
 }


### PR DESCRIPTION
## Summary

- Strip HTML-unsafe characters (`<>"'&`) from all user-supplied entity names (company, org, repo, branch, sha, stage) and jobInfo map keys/values in `StageDetails` validation
- Filter out jobs with no runs from the org dashboard to prevent rendering empty entries
- Add tests verifying jobInfo parsing preserves hyphens, dots, underscores, and digits

## What changed

- **`StageDetails.java`** — Added `stripHtmlChars()` and `stripHtmlCharsFromMap()` sanitization in the builder's `validate()` method; moved `jobInfo = lower()` and branch slash replacement before null checks
- **`OrgDashboardHtmlHelper.java`** — Added `CollectionUtils.isEmpty(jobGraph.runs())` guard to skip jobs with no runs
- **`StringMapUtilTest.java`** — Two new tests confirming hyphens, dots, underscores, and digits survive `stringToMap()` parsing
- **`StageDetailsTest.java`** — Five new tests covering HTML stripping for jobInfo, entity names, sha, and preservation of safe special characters
- **Controller tests** — Added `jobInfoPreservesSpecialCharsTest` across Browse JSON/UI, Graph JSON/UI, and Trend controllers verifying realistic jobInfo values parse correctly and reach the DB lookup (404, not 400)

## Automated test plan

- [x] `mise exec -- ./gradlew test -Si` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)